### PR TITLE
Also download dhall-yaml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,4 +27,4 @@ jobs:
         run: |
           echo "dhall version: $(dhall version)"
           echo "dhall-json version: $(dhall-to-json --version)"
-          echo "dhall-yaml version: $(yaml-to-dhall --version)"
+          echo "dhall-yaml version: $(dhall-to-yaml --version)"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,3 +27,4 @@ jobs:
         run: |
           echo "dhall version: $(dhall version)"
           echo "dhall-json version: $(dhall-to-json --version)"
+          echo "dhall-yaml version: $(yaml-to-dhall --version)"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This will add the following executables to your `PATH`, making them available fo
 - `dhall-to-json`
 - `dhall-to-yaml`
 - `json-to-dhall`
+- `yaml-to-dhall`
 
 ## Inputs
 

--- a/src/action.js
+++ b/src/action.js
@@ -23,6 +23,7 @@ const releasePatterns = () => {
   return {
     core: new RegExp(`dhall-[0-9.]+.*-${platformSuffix}\.tar\.bz2`, 'i'),
     json: new RegExp(`dhall-json-[0-9.]+.*-${platformSuffix}\.tar\.bz2`, 'i'),
+    yaml: new RegExp(`dhall-yaml-[0-9.]+.*-${platformSuffix}\.tar\.bz2`, 'i'),
   }
 }
 
@@ -52,10 +53,14 @@ const fetchReleases = async () => {
   const jsonRelease = release.assets.find(asset =>
     patterns.json.test(asset.name)
   )
+  const yamlRelease = release.assets.find(asset =>
+    patterns.yaml.test(asset.name)
+  )
 
   return {
     core: coreRelease.browser_download_url,
     json: jsonRelease.browser_download_url,
+    yaml: yamlRelease.browser_download_url,
   }
 }
 
@@ -98,7 +103,7 @@ const get = url => {
 const run = async () => {
   const urls = await fetchReleases()
 
-  await exec(path.join(__dirname, 'install-dhall.sh'), [urls.core, urls.json])
+  await exec(path.join(__dirname, 'install-dhall.sh'), [urls.core, urls.json, urls.yaml])
 }
 
 try {

--- a/src/install-dhall.sh
+++ b/src/install-dhall.sh
@@ -6,9 +6,15 @@ wget --quiet $1
 echo "Downloading dhall-json from: $2"
 wget --quiet $2
 
-# Extract dhall-json first, makes shell glob easier
+echo "Downloading dhall-yaml from: $3"
+wget --quiet $3
+
+# Extract dhall-json and dhall-yaml first, makes final shell glob easier
 tar --extract --bzip2 --file dhall-json-*.tar.bz2
 rm -f dhall-json-*.tar.bz2
+
+tar --extract --bzip2 --file dhall-yaml-*.tar.bz2
+rm -f dhall-yaml-*.tar.bz2
 
 # Extract dhall now that dhall-json is done
 tar --extract --bzip2 --file dhall-*.tar.bz2


### PR DESCRIPTION
Perhaps we should add some config to specify what you need? In my case, i'd like to use the `yaml-to-dhall` tool.

Potential config example:

```yaml
jobs:
  build:
    runs-on: ubuntu-latest
    steps:
      - uses: dhall-lang/setup-dhall@v4
        with:
          download-core: true
          download-json: false
          download-yaml: true
      - run: dhall version
```

^ download core and json would default to true, yaml to false 