### PR TITLE
Bump node version from 12 to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,5 +15,5 @@ inputs:
     required: false
 
 runs:
-  using: node12
+  using: node16
   main: src/action.js


### PR DESCRIPTION
Hi,

GitHub is complaining about setup-dhall action and deprecated Node12 version:
```
deploy
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, dhall-lang/setup-dhall, actions/checkout
```