### PR TITLE
Bump node version from 16 to 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,5 +15,5 @@ inputs:
     required: false
 
 runs:
-  using: node16
+  using: node20
   main: src/action.js


### PR DESCRIPTION
Node 16 has reached end of life so this bumps the action to use node 20

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/