### PR TITLE
Bump node version from 16 to 20, also bump checkout action version to resolve node deprecations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,9 +13,10 @@ jobs:
           - macos-latest
         version:
           - 1.34.0
-          - latest
+          # Updating this from latest to 1.42.0 for now as the "latest tag" (in this case 1.42.1) doesn't have the proper binaries available for download
+          - 1.42.0
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup Dhall
         uses: ./

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,8 +13,7 @@ jobs:
           - macos-latest
         version:
           - 1.34.0
-          # Updating this from latest to 1.42.0 for now as the "latest tag" (in this case 1.42.1) doesn't have the proper binaries available for download
-          - 1.42.0
+          - latest
     steps:
       - uses: actions/checkout@v4
 

--- a/action.yml
+++ b/action.yml
@@ -15,5 +15,5 @@ inputs:
     required: false
 
 runs:
-  using: node16
+  using: node20
   main: src/action.js


### PR DESCRIPTION
As title states, this bumps the node version from 16 -> 20 as node 16 is deprecated: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Additionally, I've updated the dhall versions used to test as the latest version (1.42.1) is missing the necessary binaries.

Closes #10 