### PR TITLE
Prevent `install-dhall.sh` from sweeping errors under the rug.

### DIFF
--- a/src/install-dhall.sh
+++ b/src/install-dhall.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -eu
+
 echo "Downloading dhall from: $1"
 wget --quiet $1
 


### PR DESCRIPTION
I just had Dhall fail to install, yet the action reported success. The logs showed:
```
Fetching dhall releases from https://api.github.com/repos/dhall-lang/dhall-haskell/releases/tags/1.41.1
/home/runner/work/_actions/dhall-lang/setup-dhall/v4/src/install-dhall.sh https://github.com/dhall-lang/dhall-haskell/releases/download/1.41.1/dhall-1.41.1-x86_64-linux.tar.bz2 https://github.com/dhall-lang/dhall-haskell/releases/download/1.41.1/dhall-json-1.7.10-x86_64-linux.tar.bz2 https://github.com/dhall-lang/dhall-haskell/releases/download/1.41.1/dhall-yaml-1.2.10-x86_64-linux.tar.bz2
Downloading dhall from: https://github.com/dhall-lang/dhall-haskell/releases/download/1.41.1/dhall-1.41.1-x86_64-linux.tar.bz2
Downloading dhall-json from: https://github.com/dhall-lang/dhall-haskell/releases/download/1.41.1/dhall-json-1.7.10-x86_64-linux.tar.bz2
Downloading dhall-yaml from: https://github.com/dhall-lang/dhall-haskell/releases/download/1.41.1/dhall-yaml-1.2.10-x86_64-linux.tar.bz2
tar (child): dhall-json-*.tar.bz2: Cannot open: No such file or directory
tar (child): Error is not recoverable: exiting now
tar: Child returned status 2
tar: Error is not recoverable: exiting now
tar (child): dhall-yaml-*.tar.bz2: Cannot open: No such file or directory
tar (child): Error is not recoverable: exiting now
tar: Child returned status 2
tar: Error is not recoverable: exiting now
tar (child): dhall-*.tar.bz2: Cannot open: No such file or directory
tar (child): Error is not recoverable: exiting now
tar: Child returned status 2
tar: Error is not recoverable: exiting now
```
It seems the script forgot to set the usual fail-fast/etc flags.